### PR TITLE
network accessor needs network always

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -66,6 +66,8 @@ class XercesCConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if not self.options.network:
+            self.options.rm_safe("network_accessor")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -73,7 +75,7 @@ class XercesCConan(ConanFile):
     def requirements(self):
         if "icu" in (self.options.transcoder, self.options.message_loader):
             self.requires("icu/74.2")
-        if self.options.network_accessor == "curl":
+        if self.options.get_safe("network_accessor") == "curl":
             self.requires("libcurl/[>=7.78.0 <9]")
 
     def _validate(self, option, value, host_os):
@@ -86,7 +88,7 @@ class XercesCConan(ConanFile):
         :param os: either a single string or a tuple of strings containing the
                    OS(es) that `value` is valid on
         """
-        if self.settings.os not in host_os and getattr(self.options, option) == value:
+        if self.settings.os not in host_os and self.options.get_safe(option) == value:
             raise ConanInvalidConfiguration(f"Option '{option}={value}' is only supported on {host_os}")
 
     def validate(self):
@@ -120,13 +122,14 @@ class XercesCConan(ConanFile):
         tc.cache_variables["BUILD_SHARED_LIBS"] = "ON" if self.options.shared else "OFF"
         # https://xerces.apache.org/xerces-c/build-3.html
         tc.variables["network"] =  self.options.network
-        tc.variables["network-accessor"] = self.options.network_accessor
+        if self.options.network:
+            tc.variables["network-accessor"] = self.options.network_accessor
         tc.variables["transcoder"] = self.options.transcoder
         tc.variables["message-loader"] = self.options.message_loader
         tc.variables["xmlch-type"] = self.options.char_type
         tc.variables["mutex-manager"] = self.options.mutex_manager
         # avoid picking up system dependency
-        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_CURL"] = self.options.network_accessor != "curl"
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_CURL"] = self.options.get_safe("network_accessor") != "curl"
         tc.variables["CMAKE_DISABLE_FIND_PACKAGE_ICU"] = "icu" not in (self.options.transcoder, self.options.message_loader)
         tc.generate()
         deps = CMakeDeps(self)


### PR DESCRIPTION
The network accessor always require network option:

https://github.com/apache/xerces-c/blob/master/cmake/XercesNetAccessorSelection.cmake#L71

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
